### PR TITLE
Make PSP optional

### DIFF
--- a/modules/cluster/gke.tf
+++ b/modules/cluster/gke.tf
@@ -1,3 +1,7 @@
+locals {
+  pod_security_policy_config = var.enable_pod_security_policy ? [{ enabled = true }] : [{ enabled = false }]
+}
+
 module "gke_cluster" {
   source                           = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   version                          = "~> 7.3.0"
@@ -26,7 +30,7 @@ module "gke_cluster" {
   cluster_ipv4_cidr                = null  # To avoid conflict with ip_allocation_policy
   enable_intranode_visibility      = var.enable_intranode_visibility
 
-  pod_security_policy_config = [{ "enabled" = true }]
+  pod_security_policy_config = local.pod_security_policy_config
 
   master_authorized_networks = var.use_private_endpoints ? [
     {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -90,3 +90,8 @@ variable "use_private_endpoints" {
   description = "Use private master endpoints"
   default     = true
 }
+
+variable "enable_pod_security_policy" {
+  description = "Enable pod security policy (PSP) for the cluster. Because PSP is not compatible with all standard containers, the default is off. We recommend that this be set true if possble, or some alternative security policy mechanism used."
+  default     = false
+}

--- a/modules/platform/gke.tf
+++ b/modules/platform/gke.tf
@@ -1,3 +1,7 @@
+locals {
+  pod_security_policy_config = var.enable_pod_security_policy ? [{ enabled = true }] : [{ enabled = false }]
+}
+
 module "gke_cluster" {
   source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
   version                    = "~> 7.3.0"

--- a/modules/platform/variables.tf
+++ b/modules/platform/variables.tf
@@ -102,3 +102,8 @@ variable "ip_range_services" {
   type        = string
   default     = "prod-subnet-services-secondary"
 }
+
+variable "enable_pod_security_policy" {
+  description = "Enable pod security policy (PSP) for the cluster. Because PSP is not compatible with all standard containers, the default is off. We recommend that this be set true if possble, or some alternative security policy mechanism used."
+  default     = false
+}


### PR DESCRIPTION
Adds a new variable, enable_pod_security_policy. As noted in the variable description, pod security policy is incompatible with some existing containers. As a a result we disable by default.