### PR TITLE
Downgrade go version for compatibility with cloud-provider-gcp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/gke-enterprise-mt
 
-go 1.25.5
+go 1.24.13
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
The cloud-provider-gcp build will fail with go version > 1.25 as they are using Bazel for build. To maintain compatibilty and avoid breaking the CCM build, downgrading to a compatible go version