### PR TITLE
Downgrade go version for compatibility with cloud-provider-gcp (#38)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/gke-enterprise-mt
 
-go 1.25.5
+go 1.24.13
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
Cherrypick go.mod downgrade to release-1.0.0