### PR TITLE
Change auto-approval process for Copybara PRs and update OWNERS with gke-mt-bot

### DIFF
--- a/.github/workflows/pr-policy-checks.yaml
+++ b/.github/workflows/pr-policy-checks.yaml
@@ -86,16 +86,16 @@ jobs:
             fi
           fi
 
-      - name: Auto-Approve Copybara PR
+      - name: Auto-Approve Copybara PR (Prow & GitHub)
         if: |
           github.event.pull_request.head.ref == 'copybara-sync-pr-jobs' && 
           github.event.pull_request.user.login == 'copybara-service[bot]'
-        run: gh pr review "${{ github.event.pull_request.html_url }}" --approve -b "Automated approval for Copybara sync"
+        run: |
+          # Native GitHub Approval
+          gh pr review "${{ github.event.pull_request.html_url }}" --approve -b "Automated approval for Copybara sync"
+          # Prow Comments (requires GH_TOKEN to belong to an OWNER)
+          gh pr comment "${{ github.event.pull_request.html_url }}" --body "/lgtm"
+          gh pr comment "${{ github.event.pull_request.html_url }}" --body "/approve"
         env:
           GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Enable Auto-Merge
-        if: github.event.pull_request.head.ref == 'copybara-sync-pr-jobs'
-        run: gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash
-        env:
-          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,10 @@
 approvers:
  - iromanycheva-eng
  - swetharepakula
+ - gke-mt-bot
 reviewers:
  - iromanycheva-eng
  - swetharepakula
  - priyapande
+ - gke-mt-bot
 


### PR DESCRIPTION
The PR #59 fails as the bot is not recognized as an OWNER by Prow bot. 

NO_VERSION_BUMP